### PR TITLE
style: replacing curly brackets with double quote marks for anchorbutton class iroco-co/landing#2

### DIFF
--- a/src/lib/ImageArticle.svelte
+++ b/src/lib/ImageArticle.svelte
@@ -17,7 +17,7 @@
     <div class="imagearticle__article__buttonGroup">
       {#each buttonList as buttonModel}
         <a
-          class={`iroco-ui-button iroco-ui-button--small iroco-ui-button--dark`}
+          class="iroco-ui-button iroco-ui-button--small iroco-ui-button--dark"
           href={buttonModel.href}
           role="button"
         >

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -58,7 +58,7 @@
     </div>
     <div class="page-content__subscribe__btn">
       <a
-        class={`iroco-ui-button iroco-ui-button--regular iroco-ui-button--success`}
+        class="iroco-ui-button iroco-ui-button--regular iroco-ui-button--success"
         href="https://app.iroco.co/signup/"
       >
         <Icon name="chevron-right" color="colors.$nightBlue" />


### PR DESCRIPTION
class={`button-anchor-like-class`} => class="button-anchor-like-class"
